### PR TITLE
Add styles for pre and code: overflow, background-color, padding, etc.

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -63,3 +63,24 @@ a:focus,a:hover {
 #not-found-content h1 {
   font-size: 40px;
 }
+
+pre, code {
+  background-color: #f0f0f0;
+  overflow: auto;
+  border-radius: 3px;
+}
+
+pre {
+  line-height: 1.4;
+  padding: 5px;
+}
+
+code {
+  padding: 2px;
+}
+
+pre > code {
+  overflow: visible;
+  padding: 0;
+  white-space: pre;
+}


### PR DESCRIPTION
This makes both inline code and code blocks look similar to SO and GitHub, but without a fixed width for code blocks. It causes `<pre>` blocks to use horizontal scrolling when the window size is too narrow to show the entirety of the longest line within the `<div id="content">`. Without a change like this, the longest line will extend beyond the `<div id="content">`, which doesn't look good.