### PR TITLE
Add restriction on SD's !!/allspam per August 2016 room meeting.

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -218,6 +218,8 @@ purpose is to find spam, abusive and low-quality posts. In the SOCVR room only
 Stack Overflow posts are reported. You can find detailed info about Smokey and 
 how you can interact with it [here](https://github.com/Charcoal-SE/SmokeDetector/wiki).
 
+Because SOCVR does not moderate users, the SD commands `!!/allspam` and `!!/reportuser` are not permitted in SOCVR.
+
 <a id="smoke-detector-request-privileges"></a>To request SD privileges from the SOCVR room ping any of the room owners. They
 will check your account for the following criteria:
 


### PR DESCRIPTION
Not permitting `!!/allspam` was an explicit result of the [August 2016 room meeting](https://socvr.org/room-info/room-meetings/2016-08), which was placed in the summary on socvr.org.

I'm unsure why that restriction is not currently in the FAQ. Subsequent room meetings did not rescind that restriction. Unfortunately, this repository's history begins with 2017-03-17, so there's no way to determine if this restriction was added and then removed. I suspect that adding this restriction just slipped through the cracks.